### PR TITLE
Bump client and api

### DIFF
--- a/api controllers/package.json
+++ b/api controllers/package.json
@@ -14,7 +14,7 @@
   "license": "MIT",
   "dependencies": {
     "build-if-changed": "^1.5.5",
-    "pushkin-api": "^1.5.4"
+    "pushkin-api": "^1.6.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.10.5",

--- a/web page/package.json
+++ b/web page/package.json
@@ -17,7 +17,7 @@
     "build-if-changed": "^1.5.5",
     "js-yaml": "^4.1.0",
     "jspsych": "^7.3.3",
-    "pushkin-client": "^1.7.0",
+    "pushkin-client": "^1.7.1",
     "react": "^18.2.0",
     "react-router-dom": "^5.2.0"
   },


### PR DESCRIPTION
Bumping the versions of the client and api as a result of merging pushkin-consortium/pushkin-client#39 and pushkin-consortium/pushkin-api#20. This can be approved after new versions of the api and client are published to npm.